### PR TITLE
Update html-elements-webpack-plugin.js

### DIFF
--- a/lib/html-elements-webpack-plugin.js
+++ b/lib/html-elements-webpack-plugin.js
@@ -21,7 +21,8 @@ HtmlElementsWebpackPlugin.prototype.apply = function (compiler) {
                             });
                     }
 
-                    callback(null, htmlPluginData);
+                   if (typeof callback === 'function')
+                        callback(null, htmlPluginData);
                 });
         });
 };


### PR DESCRIPTION
By adding callback type check it will eliminate error for webpack 4 
  - html-elements-webpack-plugin.js:24 
    [webpack4]/[html-elements-webpack-plugin]/lib/html-elements-webpack-plugin.js:24:21